### PR TITLE
[KiCad 9][Added] Preliminary support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,15 @@ on:
 
 env:
   kibot_config: kibot_yaml/kibot_main.yaml
-
   # Used variant. We assume:
   # DRAFT: only schematic in progress, will only generate schematic PDF, netlist and BoM
   # PRELIMINARY: will generate both schematic and PCB documents, but no ERC/DRC
   # CHECKED: will generate both schematic and PCB documents, with ERC/DRC
   # RELEASED: similar to CHECKED, automatically selected when pushing a tag to master
-
   kibot_variant: DRAFT
+
+  # Set the KiCad version to 8 (or change to 9 for the new version)
+  kicad_version: 8
 
 permissions:
   contents: write
@@ -125,9 +126,9 @@ jobs:
           echo "version_arg=${version_arg}" >> $GITHUB_ENV
           echo "additional_args=${additional_args}" >> $GITHUB_ENV
 
-
-      - name: Generate notes (Skipped for DRAFT variant)
-        if: ${{ env.kibot_variant != 'DRAFT' }}
+      # Generate notes (skipped for DRAFT variant)
+      - name: Generate notes (KiCad 8)
+        if: ${{ env.kicad_version == '8' && env.kibot_variant != 'DRAFT' }}
         uses: INTI-CMNB/KiBot@v2_dk8
         with:
           targets: notes
@@ -135,8 +136,18 @@ jobs:
           variant: ${{ env.kibot_variant }}
           config: ${{ env.kibot_config }}
 
-      - name: Generate README only (only for DRAFT variant)
-        if: ${{ env.kibot_variant == 'DRAFT' }}
+      - name: Generate notes (KiCad 9)
+        if: ${{ env.kicad_version == '9' && env.kibot_variant != 'DRAFT' }}
+        uses: INTI-CMNB/KiBot@v2_dk9
+        with:
+          targets: notes
+          skip: all
+          variant: ${{ env.kibot_variant }}
+          config: ${{ env.kibot_config }}
+
+      # Generate README only (only for DRAFT variant)
+      - name: Generate README only (KiCad 8)
+        if: ${{ env.kicad_version == '8' && env.kibot_variant == 'DRAFT' }}
         uses: INTI-CMNB/KiBot@v2_dk8
         with:
           targets: md_readme
@@ -144,8 +155,28 @@ jobs:
           variant: ${{ env.kibot_variant }}
           config: ${{ env.kibot_config }}
 
-      - name: Generate outputs
+      - name: Generate README only (KiCad 9)
+        if: ${{ env.kicad_version == '9' && env.kibot_variant == 'DRAFT' }}
+        uses: INTI-CMNB/KiBot@v2_dk9
+        with:
+          targets: md_readme
+          skip: draw_fancy_stackup,set_text_variables,erc,drc
+          variant: ${{ env.kibot_variant }}
+          config: ${{ env.kibot_config }}
+
+      # Generate outputs
+      - name: Generate outputs (KiCad 8)
+        if: ${{ env.kicad_version == '8' }}
         uses: INTI-CMNB/KiBot@v2_dk8
+        with:
+          additional_args: ${{ env.additional_args }}
+          variant: ${{ env.kibot_variant }}
+          config: ${{ env.kibot_config }}
+          cache3D: YES
+
+      - name: Generate outputs (KiCad 9)
+        if: ${{ env.kicad_version == '9' }}
+        uses: INTI-CMNB/KiBot@v2_dk9
         with:
           additional_args: ${{ env.additional_args }}
           variant: ${{ env.kibot_variant }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ env:
 
   # Set the KiCad version to 8 (or change to 9 for the new version)
   kicad_version: 8
-
+ 
 permissions:
   contents: write
 
@@ -43,17 +43,6 @@ jobs:
           git config --global user.name "GitHub Actions"
           git fetch
           git pull origin main
-          
-      - name: Extract release notes
-        uses: ffurrer2/extract-release-notes@v2
-        id: extract-release-notes
-        with:
-          prerelease: true
-
-      - name: Update changelog
-        uses: thomaseizinger/keep-a-changelog-new-release@v2
-        with:
-          tag: ${{ github.ref_name }}
 
       - name: Release
         uses: docker://antonyurchenko/git-release:v5
@@ -69,14 +58,6 @@ jobs:
             3D/*.step
             Testing/Testpoints/*.csv
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          branch: master
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
-          push_options: '--force'
-
   generate_outputs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Merge pull request') || github.ref_type == 'tag'"
@@ -85,6 +66,37 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Run these changelog update steps only on tag pushes
+      - name: Pull latest changes for changelog update
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git fetch
+          git pull origin main
+
+      - name: Extract release notes
+        if: ${{ github.ref_type == 'tag' }}
+        uses: ffurrer2/extract-release-notes@v2
+        id: extract-release-notes
+        with:
+          prerelease: true
+
+      - name: Update changelog
+        if: ${{ github.ref_type == 'tag' }}
+        uses: thomaseizinger/keep-a-changelog-new-release@v2
+        with:
+          tag: ${{ github.ref_name }}
+
+      - name: Commit updated CHANGELOG
+        if: ${{ github.ref_type == 'tag' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md
+          push_options: '--force'
 
       - name: Cache 3D models data
         id: models-cache
@@ -106,23 +118,16 @@ jobs:
             echo "kibot_variant=${{ env.kibot_variant }}" >> $GITHUB_ENV
           fi
 
-          # Determine group argument based on KiCad version
-          if [[ "$kicad_version" == "9" ]]; then
-            group_arg="all_group_k9"
-          else
-            group_arg="all_group"
-          fi
-
           # Determine additional_args based on the variant
           case "$kibot_variant" in
             "DRAFT")
               additional_args="--skip-pre draw_fancy_stackup,erc,drc ${version_arg} draft_group"
               ;;
             "PRELIMINARY")
-              additional_args="--skip-pre erc,drc ${version_arg} ${group_arg}"
+              additional_args="--skip-pre erc,drc ${version_arg} all_group"
               ;;
             "CHECKED"|"RELEASED")
-              additional_args="${version_arg} ${group_arg}"
+              additional_args="${version_arg} all_group"
               ;;
             *)
               echo "Unknown variant: $kibot_variant"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,16 +106,23 @@ jobs:
             echo "kibot_variant=${{ env.kibot_variant }}" >> $GITHUB_ENV
           fi
 
+          # Determine group argument based on KiCad version
+          if [[ "$kicad_version" == "9" ]]; then
+            group_arg="all_group_k9"
+          else
+            group_arg="all_group"
+          fi
+
           # Determine additional_args based on the variant
           case "$kibot_variant" in
             "DRAFT")
               additional_args="--skip-pre draw_fancy_stackup,erc,drc ${version_arg} draft_group"
               ;;
             "PRELIMINARY")
-              additional_args="--skip-pre erc,drc ${version_arg} all_group"
+              additional_args="--skip-pre erc,drc ${version_arg} ${group_arg}"
               ;;
             "CHECKED"|"RELEASED")
-              additional_args="${version_arg} all_group"
+              additional_args="${version_arg} ${group_arg}"
               ;;
             *)
               echo "Unknown variant: $kibot_variant"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ env:
   # DRAFT: only schematic in progress, will only generate schematic PDF, netlist and BoM
   # PRELIMINARY: will generate both schematic and PCB documents, but no ERC/DRC
   # CHECKED: will generate both schematic and PCB documents, with ERC/DRC
-  # RELEASED: similar to CHECKED, automatically selected when pushing a tag to master
+  # RELEASED: similar to CHECKED, automatically selected when pushing a tag to main
   kibot_variant: DRAFT
 
   # Set the KiCad version to 8 (or change to 9 for the new version)
@@ -219,8 +219,13 @@ jobs:
             git pull origin ${{ github.ref_name }} --tags --force
           fi
 
-      - name: Discard changes to .kicad_pcb files
-        run: git checkout HEAD -- *.kicad_pcb
+      - name: Discard changes to .kicad_pcb files and remove temp files
+        run: | 
+          git checkout HEAD -- $(git ls-files "*.kicad_pcb")
+          git clean -f "*.kicad_pcb"
+          git clean -f "*.kicad_pro"
+          git clean -f "*.kicad_dru"
+          git clean -f "*.kicad_prl"
 
       - name: Update Outputs
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *-backups
 \#auto_saved_files#
+_autosave-*
 *.lck
 *.bak
 *.ini

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You should move this file to your KiCad Themes folder.
    git checkout -b dev
    ```
    
-7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L559) according to your project:
+7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L555) according to your project:
     ```
       # Metadata ===================================================================
 
@@ -334,7 +334,7 @@ You can also specify a variant if desired:
 For more information, please have a look at the official [documentation](https://hildogjr.github.io/KiCost/docs/_build/singlehtml/index.html)
 
 > [!CAUTION]
-> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L579) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
+> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L575) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
 
 <p align="center">
   <img alt="XLSX BoM" src="https://github.com/user-attachments/assets/e7683ae3-efcc-4f64-b4b7-c4c39c3c9d48">
@@ -420,7 +420,7 @@ To synchronise the Revision History of the schematic with the `CHANGELOG.md` fil
 
 ### PCB
 
-The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L634). 
+The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L630). 
 
 ```
   LAYER_TITLE_PAGE: TitlePage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">KiCad Template for CI/CD with KiBot</h1>
+<h1 align="center">KiCad 8/9 Template for CI/CD with KiBot</h1>
 
 <p align="center">
   <a href=https://www.kicad.org/>
@@ -10,7 +10,7 @@
   </a>
 </p>
 
-A KiCad 8/9 template for **automated**, professional documentation generation with **Continuous Integration and Continuous Development** (CI/CD) using [KiBot](https://github.com/INTI-CMNB/KiBot/tree/master).
+A **KiCad 8/9** template for **automated**, professional documentation generation with **Continuous Integration and Continuous Development** (CI/CD) using [KiBot](https://github.com/INTI-CMNB/KiBot/tree/master). KiCad 9 support is still experimental.
 
 A video tutorial for setting up this template is available [here]().
 
@@ -111,7 +111,7 @@ You should move this file to your KiCad Themes folder.
    git checkout -b dev
    ```
    
-7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L555) according to your project:
+7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L556) according to your project:
     ```
       # Metadata ===================================================================
 
@@ -227,10 +227,9 @@ This template is meant to be used in a CI/CD environment on GitHub. The workflow
 
   This will start a KiBot run with the variant set as `RELEASED`. When the run completes, it also creates a release with assets and updates the `CHANGELOG.md` file (renames the `[Unreleased]` section with the pushed tag and creates a new `[Unreleased]` section).
 
-- After a release, you will need to update your `main` branch and rebase your `dev` branch with the `main` branch:
+- After a release, you will need to update your `main` branch to be up-to-date with the remote:
 
   ```
-  git fetch origin
   git pull
   ```
 
@@ -289,6 +288,16 @@ The easiest way to install KiBot if custom development is not required is with d
 
 Once in the docker, you can use the [`kibot_launch.sh`](kibot_launch.sh) script to generate and visualize outputs.
 
+```
+./kibot_launch.sh
+```
+
+You can get more information about the usage with
+
+```
+./kibot_launch.sh --help
+```
+
 When running the script with no arguments, it will default to the `CHECKED` variant and generate all outputs. A variant can be set with the `-v` flag. If a custom variant is used (i.e. other than the default variants `DRAFT`, `PRELIMINARY`, `CHECKED`, `RELEASED`), the outputs will be generated in the `Variants` folder.
 
 Each default variant will have different KiBot flags, which is useful for different phases of the project:
@@ -334,7 +343,7 @@ You can also specify a variant if desired:
 For more information, please have a look at the official [documentation](https://hildogjr.github.io/KiCost/docs/_build/singlehtml/index.html)
 
 > [!CAUTION]
-> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L575) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
+> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L576) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
 
 <p align="center">
   <img alt="XLSX BoM" src="https://github.com/user-attachments/assets/e7683ae3-efcc-4f64-b4b7-c4c39c3c9d48">
@@ -420,7 +429,7 @@ To synchronise the Revision History of the schematic with the `CHANGELOG.md` fil
 
 ### PCB
 
-The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L630). 
+The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L631). 
 
 ```
   LAYER_TITLE_PAGE: TitlePage
@@ -652,7 +661,7 @@ The following directory structure is used in the template. Folders marked as 'op
 
 - [Video Tutorial for this template]()
 
-- [Example project (from the video tutorial)]()
+- [Example project (from the video tutorial)](https://github.com/nguyen-v/KiBot_Project_Test)
 
 - [Example project (Amulet)](https://github.com/nguyen-v/amulet_controller_kibot/tree/master)
 

--- a/README.md
+++ b/README.md
@@ -98,17 +98,20 @@ You should move this file to your KiCad Themes folder.
 
     `~/.config/kicad/8.0/colors`
 
-1. Create a new project with:
+> [!NOTE]
+> In the steps above, replace ```8.0``` with ```9.0``` for KiCad 9
+
+5. Create a new project with:
 
     **File → New Project From Template** and select `KDT_Hierarchical_KiBot`
 
-2. Create a new `dev` branch. This will be the working branch. 
+6. Create a new `dev` branch. This will be the working branch. 
    
    ```
    git checkout -b dev
    ```
    
-3. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L528) according to your project:
+7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L528) according to your project:
     ```
       # Metadata ===================================================================
 
@@ -161,11 +164,11 @@ You should move this file to your KiCad Themes folder.
       KEY_COLOR: '#00FF00' # background color to remove
     ```
 
-4. The files inside of [`kibot_resources/templates`](kibot_resources/templates) should also be modified according to your project. These include Assembly and Fabrication notes, Impedance table and README file templates.
+8. The files inside of [`kibot_resources/templates`](kibot_resources/templates) should also be modified according to your project. These include Assembly and Fabrication notes, Impedance table and README file templates.
 
-5. Edit the [`*.kicad_dru`](KDT_Hierarchical_KiBot.kicad_dru) if necessary according to your design rules. Right now, it has been set for PCBWay 6-layer PCBs with 2oz outer 1oz inner, focusing on lowest cost.
+9. Edit the [`*.kicad_dru`](KDT_Hierarchical_KiBot.kicad_dru) if necessary according to your design rules. Right now, it has been set for PCBWay 6-layer PCBs with 2oz outer 1oz inner, focusing on lowest cost.
 
-6. Edit the [`kibot_out_csv_bom.yaml`](kibot_yaml/kibot_out_csv_bom.yaml), [`kibot_out_html_bom.yaml`](kibot_yaml/kibot_out_html_bom.yaml) and [`kibot_out_xlsx_bom.yaml`](kibot_yaml/kibot_out_xlsx_bom.yaml) files according to the component fields that you use. You can refer to the [KiCost Documentation](https://hildogjr.github.io/KiCost/docs/_build/singlehtml/index.html) for the field names.
+10.  Edit the [`kibot_out_csv_bom.yaml`](kibot_yaml/kibot_out_csv_bom.yaml), [`kibot_out_html_bom.yaml`](kibot_yaml/kibot_out_html_bom.yaml) and [`kibot_out_xlsx_bom.yaml`](kibot_yaml/kibot_out_xlsx_bom.yaml) files according to the component fields that you use. You can refer to the [KiCost Documentation](https://hildogjr.github.io/KiCost/docs/_build/singlehtml/index.html) for the field names.
 
 ## USAGE
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You should move this file to your KiCad Themes folder.
    git checkout -b dev
    ```
    
-7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L528) according to your project:
+7. Modify the following fields in [`kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L559) according to your project:
     ```
       # Metadata ===================================================================
 
@@ -334,7 +334,7 @@ You can also specify a variant if desired:
 For more information, please have a look at the official [documentation](https://hildogjr.github.io/KiCost/docs/_build/singlehtml/index.html)
 
 > [!CAUTION]
-> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L544) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
+> KiCost expects the **MPN (Manufacturer Part Number)** and **Manufacturer** fields to be named in a certain way. To cater for different naming conventions, we rename user-defined fields to KiCost-compatible fields in the KiBot run. You can set your user-defined field for **MPN** and **Manufacturer** in the [`kibot_yaml/kibot_main.yaml`](kibot_yaml/kibot_main.yaml#L579) by editing the `MPN_FIELD` and `MAN_FIELD` definitions.
 
 <p align="center">
   <img alt="XLSX BoM" src="https://github.com/user-attachments/assets/e7683ae3-efcc-4f64-b4b7-c4c39c3c9d48">
@@ -420,7 +420,7 @@ To synchronise the Revision History of the schematic with the `CHANGELOG.md` fil
 
 ### PCB
 
-The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L599). 
+The layer names of the PCB should follow the ones defined in [kibot_main.yaml](kibot_yaml/kibot_main.yaml#L634). 
 
 ```
   LAYER_TITLE_PAGE: TitlePage

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   </a>
 </p>
 
-A KiCad 8 template for **automated**, professional documentation generation with **Continuous Integration and Continuous Development** (CI/CD) using [KiBot](https://github.com/INTI-CMNB/KiBot/tree/master). KiCad 9 will most likely be supported in the near future.
+A KiCad 8/9 template for **automated**, professional documentation generation with **Continuous Integration and Continuous Development** (CI/CD) using [KiBot](https://github.com/INTI-CMNB/KiBot/tree/master).
 
 A video tutorial for setting up this template is available [here]().
 
@@ -175,11 +175,14 @@ This template is meant to be used in a CI/CD environment on GitHub. The workflow
 
 - Any custom font used in the project must be added to the [`kibot_resources/fonts`](kibot_resources/fonts) folder.
 
+> [!NOTE]
+> KiCad 9 allows for fonts to be embedded in the schematic. However, it is still good practice to add the fonts in the folder mentioned.
+
 - There are two branches, a `main` and a `dev` branch. The `dev` branch is the working branch. The `main` should only be used for pull requests and releases.
 
 - Changes should be recorded in the [`CHANGELOG.md`](CHANGELOG.md) file, and should respect [semantic versioning guidelines](https://semver.org/) for [hardware](https://www.maskset.net/blog/2023/02/26/semantic-versioning-for-hardware/). The changes of the current version should be added under the `[Unreleased]` section.
 
-- The `variant` variable in [.github/workflows/ci.yaml](.github/workflows/ci.yaml#L23) should be selected according to the project progress.
+- The `variant` variable in [.github/workflows/ci.yaml](.github/workflows/ci.yaml#L21) should be selected according to the project progress.
 
   ```
     # Used variant. We assume:
@@ -190,6 +193,8 @@ This template is meant to be used in a CI/CD environment on GitHub. The workflow
 
     kibot_variant: CHECKED  
   ```
+
+- The `kicad_version` variable in [.github/workflows/ci.yaml](.github/workflows/ci.yaml#L24) should be selected according to the desired KiCad version. Supported versions are 8 and 9.
 
 - You should work locally on the `dev` branch. When a change is made, the changes should be pushed to GitHub which will trigger the KiBot workflow. The generated files will be committed and pushed back to the repository.
 
@@ -246,21 +251,38 @@ The easiest way to install KiBot if custom development is not required is with d
 
 1.  Install **and run** [Docker Desktop](https://docs.docker.com/desktop/)
   
-2.  Run the script `docker_kibot_windows.bat` or `docker_kibot_linux.sh` depending on your platform in [`kibot_resources/scripts`](kibot_resources/scripts). Currently tested on Windows and WSL2.
-  
-  **Windows**:
+2.  Run the script `docker_kibot_windows.bat` or `docker_kibot_linux.sh` depending on your platform in [`kibot_resources/scripts`](kibot_resources/scripts). Currently tested on Windows and WSL2. This should pull and start a docker running the `dev` branch of KiBot. You should have access to your local files.
+
+***
+**KiCad 8**
+
+  Windows:
 
   ```
   .\docker_kibot_windows.bat
   ```
 
-  **Linux**:
+  Linux:
 
   ```
   ./docker_kibot_linux.sh
   ```
 
-This should pull and start a docker running the `dev` branch of KiBot, on KiCad 8. You should have access to your local files.
+***
+**KiCad 9**
+
+  Windows:
+
+  ```
+  .\docker_kibot_windows.bat -v 9
+  ```
+
+  Linux:
+
+  ```
+  ./docker_kibot_linux.sh -v 9
+  ```
+  ***
 
 Once in the docker, you can use the [`kibot_launch.sh`](kibot_launch.sh) script to generate and visualize outputs.
 

--- a/kibot_launch.sh
+++ b/kibot_launch.sh
@@ -130,6 +130,14 @@ if [[ -z "$revision" ]]; then
     fi
 fi
 
+# Check KiCad version and set group command accordingly
+kicad_version=$(kicad-cli --version)
+if [ "$(printf '%s\n' "9.0.0" "$kicad_version" | sort -V | head -n1)" = "9.0.0" ]; then
+    all_group="all_group_k9"
+else
+    all_group="all_group"
+fi
+
 # Handle server flag
 if [[ "$server_flag" == true ]]; then
     echo -e "${GREEN}Starting HTTP server on port $server_port...${NC}"
@@ -165,7 +173,7 @@ else
             ;;
         CHECKED|RELEASED|*)
             kibot_command1="$kibot_base --skip-pre set_text_variables,draw_fancy_stackup,erc,drc $kibot_config -d '$output_dir' -g variant=$variant -E REVISION='$revision' notes"
-            kibot_command2="$kibot_base $kibot_config -d '$output_dir' -g variant=$variant -E REVISION='$revision' all_group"
+            kibot_command2="$kibot_base $kibot_config -d '$output_dir' -g variant=$variant -E REVISION='$revision' $all_group"
             ;;
     esac
 fi

--- a/kibot_resources/scripts/docker_kibot_linux.sh
+++ b/kibot_resources/scripts/docker_kibot_linux.sh
@@ -1,12 +1,34 @@
 #!/bin/sh
+
+# Default image version
+IMAGE="ghcr.io/inti-cmnb/kicad8_auto_full:dev"
+
+# Parse the optional -v flag
+while getopts "v:" opt; do
+    case "$opt" in
+        v)
+            if [ "$OPTARG" = "9" ]; then
+                IMAGE="ghcr.io/inti-cmnb/kicad9_auto_full:dev"
+            else
+                echo "Unsupported version: $OPTARG" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Usage: $0 [-v 9]" >&2
+            exit 1
+            ;;
+    esac
+done
+
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 export USER_NAME=$(whoami)
 
 docker run --rm -it \
-    --user $USER_ID:$GROUP_ID \
+    --user "$USER_ID:$GROUP_ID" \
     --env NO_AT_BRIDGE=1 \
-    --env DISPLAY=$DISPLAY \
+    --env DISPLAY="$DISPLAY" \
     --workdir="/home/$USER_NAME" \
     --volume=/tmp/.X11-unix:/tmp/.X11-unix \
     --volume="/etc/group:/etc/group:ro" \
@@ -14,11 +36,10 @@ docker run --rm -it \
     --volume="/etc/shadow:/etc/shadow:ro" \
     --volume="/home/$USER_NAME:/home/$USER_NAME:rw" \
     --entrypoint /bin/bash \
-    ghcr.io/inti-cmnb/kicad8_auto_full:dev -c "
+    "$IMAGE" -c "
     if ! id $USER_NAME &>/dev/null; then
         echo \"Creating user $USER_NAME ($USER_ID:$GROUP_ID)...\"
         useradd -u $USER_ID -g $GROUP_ID -d /home/$USER_NAME -m $USER_NAME
         chown -R $USER_ID:$GROUP_ID /home/$USER_NAME
     fi
     exec su - $USER_NAME"
-

--- a/kibot_resources/scripts/docker_kibot_windows.bat
+++ b/kibot_resources/scripts/docker_kibot_windows.bat
@@ -1,7 +1,20 @@
 @echo off
-REM Set variables for user ID, group ID, and display
+REM Set variables for display and user name
 set DISPLAY=host.docker.internal:0.0
 set USER_NAME=%USERNAME%
+
+REM Set default image
+set "IMAGE=ghcr.io/inti-cmnb/kicad8_auto_full:dev"
+
+REM Check for optional -v flag and version number
+if /I "%~1"=="-v" (
+    if "%~2"=="9" (
+        set "IMAGE=ghcr.io/inti-cmnb/kicad9_auto_full:dev"
+    ) else (
+        echo Unsupported version: %~2
+        goto :eof
+    )
+)
 
 REM Run the Docker container with mounted volumes
 docker run --rm -it ^
@@ -11,4 +24,4 @@ docker run --rm -it ^
     --volume=C:\Users\%USER_NAME%:/home/%USER_NAME%:rw ^
     --volume=/tmp/.X11-unix:/tmp/.X11-unix ^
     --entrypoint /bin/bash ^
-    ghcr.io/inti-cmnb/kicad8_auto_full:dev
+    %IMAGE%

--- a/kibot_yaml/kibot_main.yaml
+++ b/kibot_yaml/kibot_main.yaml
@@ -148,10 +148,6 @@ groups:
       - @STEP_OUTPUT@
       # - @BLENDER_OUTPUT@ # looks kinda bad
 
-  - name: ki9
-    outputs:
-      - @ODB_OUTPUT@
-
 import:
 
   # Global parameters ==========================================================

--- a/kibot_yaml/kibot_main.yaml
+++ b/kibot_yaml/kibot_main.yaml
@@ -467,6 +467,7 @@ import:
       COMMENT: Schematic in PDF format
       COLOR_THEME: @COLOR_THEME@
       DIR: @SCHEMATIC_DIR@
+      DEFAULT_FONT: 'Times New Roman'
 
   # Fabrication Document in PDF format
   - file: kibot_out_pdf_fabrication.yaml

--- a/kibot_yaml/kibot_main.yaml
+++ b/kibot_yaml/kibot_main.yaml
@@ -63,6 +63,19 @@ groups:
       - @HTML_KIRI_OUTPUT@
       - @HTML_NAV_RES_OUTPUT@
 
+  - name: all_group_k9
+    outputs:
+      - @NETLIST_OUTPUT@
+      - bom
+      - 3d
+      - fab_k9
+      - assembly
+      - @PDF_SCHEMATIC_OUTPUT@
+      - @MD_README_OUTPUT@
+      # - @HTML_KICANVAS_OUTPUT@ # Very experimental, we exclude it for now
+      - @HTML_KIRI_OUTPUT@
+      - @HTML_NAV_RES_OUTPUT@
+
   - name: draft_group
     outputs:
       - @NETLIST_OUTPUT@
@@ -74,6 +87,17 @@ groups:
     outputs:
       - tables
       - @GERBER_OUTPUT@
+      - @EXCELLON_DRILL_OUTPUT@
+      # - @DXF_DRILL_MAP_OUTPUT@
+      - @PDF_DRILL_MAP_OUTPUT@
+      - @PDF_FABRICATION_OUTPUT@
+      - @ZIP_COMPRESS_FAB_OUTPUT@
+
+  - name: fab_k9
+    outputs:
+      - tables
+      - @GERBER_OUTPUT@
+      - @ODB_OUTPUT@
       - @EXCELLON_DRILL_OUTPUT@
       # - @DXF_DRILL_MAP_OUTPUT@
       - @PDF_DRILL_MAP_OUTPUT@
@@ -123,6 +147,10 @@ groups:
     outputs:
       - @STEP_OUTPUT@
       # - @BLENDER_OUTPUT@ # looks kinda bad
+
+  - name: ki9
+    outputs:
+      - @ODB_OUTPUT@
 
 import:
 
@@ -229,6 +257,13 @@ import:
       COMMENT: Gerbers in GBR format
       DIR: @GERBERS_DIR@
       PLOT_REFS: @PLOT_REFS@
+
+  # ODB++ ----------------------------------------------------------------------
+  - file: kibot_out_odb.yaml
+    definitions:
+      NAME: @ODB_OUTPUT@
+      COMMENT: ODB++ in ZIP format
+      DIR: @FABRICATION_DIR@
 
   # Drill files
   - file: kibot_out_excellon_drill.yaml
@@ -622,6 +657,7 @@ definitions:
   NETLIST_OUTPUT: netlist
 
   GERBER_OUTPUT: gbr_gerbers
+  ODB_OUTPUT: zip_odb
   EXCELLON_DRILL_OUTPUT: drl_excellon
   PDF_DRILL_MAP_OUTPUT: pdf_drill_map
   DXF_DRILL_MAP_OUTPUT: dxf_drill_map

--- a/kibot_yaml/kibot_out_odb.yaml
+++ b/kibot_yaml/kibot_out_odb.yaml
@@ -1,0 +1,21 @@
+# KiBot output for generating ODB++ files
+# https://kibot.readthedocs.io/en/latest/configuration/outputs/odb.html
+
+kibot:
+  version: 1
+
+outputs:
+- name: @NAME@
+  comment: '@COMMENT@'
+  type: odb
+  category: '@DIR@'
+  dir: '@DIR@'
+  options:
+    dnf_filter: _kibom_dnf_Config
+
+...
+definitions:
+  NAME: zip_odb
+  COMMENT: ODB++ in ZIP format
+  DIR: Manufacturing/Fabrication
+  PLOT_REFS: true

--- a/kibot_yaml/kibot_out_odb.yaml
+++ b/kibot_yaml/kibot_out_odb.yaml
@@ -18,4 +18,3 @@ definitions:
   NAME: zip_odb
   COMMENT: ODB++ in ZIP format
   DIR: Manufacturing/Fabrication
-  PLOT_REFS: true

--- a/kibot_yaml/kibot_out_pdf_schematic.yaml
+++ b/kibot_yaml/kibot_out_pdf_schematic.yaml
@@ -13,9 +13,11 @@ outputs:
   options:
     background_color: false
     color_theme: '@COLOR_THEME@'
+    default_font: '@DEFAULT_FONT@'
 
 definitions:
   NAME: pdf_schematic
   COMMENT: Schematic in PDF format
   COLOR_THEME: Altium_Theme
+  DEFAULT_FONT: Times New Roman
   DIR: Schematic


### PR DESCRIPTION
Preliminary support for KiCad 9, both locally and with CI/CD. All of the old functions are supported, with some new additions:
- Support for default font in PDF schematic
- ODB++ export as a ZIP file. Is also added to the assets with each release.

Known issues:
- https://github.com/INTI-CMNB/KiBot/issues/788