### PR TITLE
Add output for Mouser BOM tool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           args: |
             Schematic/*.pdf
+            Purchasing/*
             Manufacturing/Assembly/*
             Manufacturing/Fabrication/*.pdf
             Manufacturing/Fabrication/*.zip

--- a/kibot_yaml/kibot_main.yaml
+++ b/kibot_yaml/kibot_main.yaml
@@ -123,6 +123,7 @@ groups:
       # - @XLSX_BOM_OUTPUT@
       - @HTML_IBOM_OUTPUT@
       - @HTML_BOM_OUTPUT@
+      # - @MOUSER_BOM_OUTPUT@
 
   - name: tables
     outputs:
@@ -332,6 +333,12 @@ import:
       EXCLUDE_FILTER: @FILT_TP_BOTTOM_ONLY@
 
   # CSV Bill of Materials (BoM) ------------------------------------------------
+  - file: kibot_out_mouser_bom.yaml
+    definitions:
+      NAME: @MOUSER_BOM_OUTPUT@
+      COMMENT: BOM for the Mouser BOM-Tool
+      DIR: @PURCHASING_DIR@
+
   - file: kibot_out_csv_bom.yaml
     definitions:
       NAME: @CSV_BOM_OUTPUT@
@@ -613,6 +620,7 @@ definitions:
   # Relative to root
   REPORT_DIR: Reports
   SCHEMATIC_DIR: Schematic
+  PURCHASING_DIR: 'Purchasing'
   MANUFACTURING_DIR: Manufacturing
   ASSEMBLY_DIR: '@MANUFACTURING_DIR@/Assembly'
   FABRICATION_DIR: '@MANUFACTURING_DIR@/Fabrication'
@@ -669,6 +677,7 @@ definitions:
   XLSX_BOM_OUTPUT: xlsx_bom
   HTML_IBOM_OUTPUT: html_bom_interactive
   HTML_BOM_OUTPUT: html_bom
+  MOUSER_BOM_OUTPUT: mouser_bom
   CSV_COMP_COUNT_OUPUT: csv_comp_count
   CSV_IMPEDANCE_TABLE_OUTPUT: csv_impedance_table
 

--- a/kibot_yaml/kibot_out_mouser_bom.yaml
+++ b/kibot_yaml/kibot_out_mouser_bom.yaml
@@ -1,0 +1,45 @@
+# KiBot output for generating Bill of Materials in XLSX format for the Mouser BOM tool
+# https://kibot.readthedocs.io/en/latest/configuration/outputs/bom.html
+
+kibot:
+  version: 1
+
+outputs:
+- name: @NAME@
+  comment: '@COMMENT@'
+  type: bom
+  category: '@DIR@'
+  dir: '@DIR@'
+  options:
+    format: XLSX
+    count_smd_tht: true
+    output: "BOM_Mouser.%x"
+    ref_separator: ','
+    xlsx:
+      kicost: false
+      specs: false
+      title: "%f BOM"
+      hide_stats_info: true
+      hide_pcb_info: true
+      logo: false
+      col_colors: false
+      style: "classic"
+      title: ""
+
+    columns:
+      - field: manf#
+        name: Manufacturer Part Number
+      - field: mouser#
+        name: Mouser Part Number
+      - field: manf#
+        name: Manufacturer Name
+      - field: Value
+        name: Description
+      - field: Build Quantity
+        name: Quantity
+
+...
+definitions:
+  NAME: mouser_bom
+  COMMENT: BOM for the Mouser BOM-Tool
+  DIR: Purchasing


### PR DESCRIPTION
The output file can be imported into Mouser´s BOM tool to automatically add the components for `n` PCBs to the basket

https://www.mouser.de/help/tools/how-to-create-a-new-bom?srsltid=afmboopehk-ggmwnw21rso0nx683ti5064zcde5xkbmqsckhsazfdv5e

This simplifies the ordering of the components for complete PCBs drastically.